### PR TITLE
default heatmap diasable

### DIFF
--- a/store/monitoring.js
+++ b/store/monitoring.js
@@ -19,7 +19,7 @@ export const state = () => ({
     },
 
     opacity: 100,
-    heatMap: true,
+    heatMap: false,
     total: null,
     tableMonitoring: [],
     tableCSVMonitoring: [],

--- a/store/priority.js
+++ b/store/priority.js
@@ -1,7 +1,7 @@
 export const state = () => ({
     features: null,
     showFeatures: false,
-    heatMap: true,
+    heatMap: false,
     tableDialogPriority: false,
     isLoadingTable: true,
     isLoadingFeatures: false,

--- a/store/urgent-alerts.js
+++ b/store/urgent-alerts.js
@@ -1,7 +1,7 @@
 export const state = () => ({
     features: null,
     showFeaturesUrgentAlert: false,
-    heatMap: true,
+    heatMap: false,
     tableDialogAlert: false,
     isLoadingTable: true,
     isLoadingFeatures: false,


### PR DESCRIPTION
O estatus inicial do heatmap foi colocado como falso, para que ele comece desligado após a filtragem.